### PR TITLE
Simplify Open query

### DIFF
--- a/_♻️ Templates/0. 📓 Daily.md
+++ b/_♻️ Templates/0. 📓 Daily.md
@@ -189,7 +189,7 @@ dv.taskList(Array.from([result.values[selected]]), false)
 task
 from #log 
 where !completed 
-and (date(split(split(string(section), "/")[length(split(string(section), "/"))-1], ",")[0]) < date(today))
+and (file.day < date(today))
 and !contains(string(section), "Lessons") and !contains(string(text), "🚩2")
 group by split(split(string(section), ">")[1], "]")[0]
 ```


### PR DESCRIPTION
For me, the previous version of the 🗒 Open query selected open tasks from today's daily note as well as previous days. From the comments it looks like the intended working is only to select open tasks from daily notes before today.

This version uses `file.day` to get the date from the file name and checks that against today's date. Tested with daily note titles formatted both as "YYYY-MM-DD" and "YYYY-MM-DD, ...".